### PR TITLE
Started list of previous meetings

### DIFF
--- a/previous_meetings.md
+++ b/previous_meetings.md
@@ -1,0 +1,11 @@
+---
+title: Previous meetings
+---
+
+## Previous meetings
+
+A list of previous meetings, along with any relevant notes / links / etc.
+
+Date | Title | Resources
+--- | --- | ---
+2018-04-03 | [Traits and TraitsUI: Reactive User Interfaces for Python](https://www.meetup.com/CamPUG/events/247415295/) | [slides](http://public.enthought.com/~cwebster/campug/)


### PR DESCRIPTION
I figured it might be nice if we had a page on the website where slides / resources / etc. from previous meetups could be linked to, for future reference and for the benefit of people who missed a particular meetup?
By hosting this info on Github.com rather than Meetup.com the people giving the talks will be able to create PRs to submit their own links.

Only added the most recent meeting to kick things off...